### PR TITLE
added mlx_get_screen_size, added libmlx_$(HT).a to clean, changed ft_strlcpy to _ft_strlcpy

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -45,7 +45,8 @@ SRC		=	mlx_init.c \
 			mlx_int_set_win_event_mask.c \
 			mlx_hook.c \
 			mlx_rgb.c \
-			mlx_destroy_image.c
+			mlx_destroy_image.c \
+			mlx_get_screen_size.c
 
 OBJ		=	$(SRC:.c=.o)
 CFLAGS	=	-O3 -I$(INC)
@@ -62,7 +63,7 @@ do_cp:
 	cp $(NAME) libmlx_$(HT).a
 
 clean:
-	rm -f $(OBJ) $(NAME) *~ core *.core
+	rm -f $(OBJ) $(NAME) *~ core *.core libmlx_$(HT).a
 
 install:
 	mkdir -p $(DESTDIR)/lib && cp $(NAME) $(DESTDIR)/lib

--- a/mlx.h
+++ b/mlx.h
@@ -126,4 +126,6 @@ int	mlx_do_key_autorepeatoff(void *mlx_ptr);
 int	mlx_do_key_autorepeaton(void *mlx_ptr);
 int	mlx_do_sync(void *mlx_ptr);
 
+int mlx_get_screen_size(void *mlx_ptr, int *sizex, int *sizey);
+
 #endif /* MLX_H */

--- a/mlx_get_screen_size.c
+++ b/mlx_get_screen_size.c
@@ -1,0 +1,26 @@
+/*
+ * =====================================================================================
+ *
+ *       Filename:  mlx_get_screen_size.c
+ *
+ *    Description:  
+ *
+ *        Version:  1.0
+ *        Created:  18-06-20 09:37:53
+ *       Revision:  none
+ *       Compiler:  gcc
+ *
+ *         Author:  Stan Verschuuren (), sverschu@student.codam.nl
+ *   Organization:  Codam Coding College
+ *
+ * =====================================================================================
+ */
+
+#include "mlx_int.h"
+
+int	mlx_get_screen_size(t_xvar *mlx_ptr, int *sizex, int *sizey)
+{
+	*sizex = DisplayWidth (mlx_ptr->display, mlx_ptr->screen);
+	*sizey = DisplayHeight (mlx_ptr->display, mlx_ptr->screen);
+	return (0);
+}

--- a/mlx_xpm.c
+++ b/mlx_xpm.c
@@ -41,7 +41,7 @@ char	*mlx_int_get_line(char *ptr,int *pos,int size)
   return (ptr+pos4);
 }
 
-size_t  ft_strlcpy(char *dest, const char *src, size_t size)
+size_t  _ft_strlcpy(char *dest, const char *src, size_t size)
 {
         size_t  len_src;
         size_t  i;
@@ -79,7 +79,7 @@ char	*mlx_int_static_line(char **xpm_data,int *pos,int size)
       len = len2;
     }
   /* strcpy(copy,str); */
-  ft_strlcpy(copy, str, len2+1);
+  _ft_strlcpy(copy, str, len2+1);
   return (copy);
 }
 


### PR DESCRIPTION
added mlx_get_screen_size: required for last version of Cub3D/MiniRT raycaster project (exact same prototype as the one provided by 42).

added libmlx_$(HT).a to clean

changed ft_strlcpy to _ft_strlcpy to counter namespace collision when people include Libft in their projects